### PR TITLE
Use instance properties instead of static properties for css classes

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "babel-cli": "^6.4.5",
     "babel-preset-metal": "^4.0.0",
     "gulp": "^3.8.11",
-    "gulp-metal": "^1.0.0"
+    "gulp-metal": "^1.0.0",
+    "sinon": "^1.17.7"
   }
 }

--- a/src/Toggler.js
+++ b/src/Toggler.js
@@ -99,15 +99,15 @@ class Toggler extends State {
 	 */
 	toggle(header) {
 		var content = this.getContentElement_(header);
-		dom.toggleClasses(content, Toggler.CSS_EXPANDED);
-		dom.toggleClasses(content, Toggler.CSS_COLLAPSED);
+		dom.toggleClasses(content, this.cssExpanded);
+		dom.toggleClasses(content, this.cssCollapsed);
 
-		if (dom.hasClass(content, Toggler.CSS_EXPANDED)) {
-			dom.addClasses(header, Toggler.CSS_HEADER_EXPANDED);
-			dom.removeClasses(header, Toggler.CSS_HEADER_COLLAPSED);
+		if (dom.hasClass(content, this.cssExpanded)) {
+			dom.addClasses(header, this.cssHeaderExpanded);
+			dom.removeClasses(header, this.cssHeaderCollapsed);
 		} else {
-			dom.removeClasses(header, Toggler.CSS_HEADER_EXPANDED);
-			dom.addClasses(header, Toggler.CSS_HEADER_COLLAPSED);
+			dom.removeClasses(header, this.cssHeaderExpanded);
+			dom.addClasses(header, this.cssHeaderCollapsed);
 		}
 	}
 }
@@ -140,27 +140,40 @@ Toggler.STATE = {
 	 */
 	header: {
 		validator: value => core.isString(value) || core.isElement(value)
+	},
+
+	/**
+	 * The CSS class added to the content when it's collapsed.
+	 */
+	cssCollapsed: {
+		validator: value => core.isString(value),
+		value: 'toggler-collapsed'
+	},
+
+
+	/**
+	 * The CSS class added to the content when it's expanded.
+	 */
+	cssExpanded: {
+		validator: value => core.isString(value),
+		value: 'toggler-expanded'
+	},
+
+	/**
+	 * The CSS class added to the header when the content is collapsed.
+	 */
+	cssHeaderCollapsed: {
+		validator: value => core.isString(value),
+		value: 'toggler-header-collapsed'
+	},
+
+	/**
+	 * The CSS class added to the header when the content is expanded.
+	 */
+	cssHeaderExpanded: {
+		validator: value => core.isString(value),
+		value: 'toggler-header-expanded'
 	}
 };
-
-/**
- * The CSS class added to the content when it's collapsed.
- */
-Toggler.CSS_COLLAPSED = 'toggler-collapsed';
-
-/**
- * The CSS class added to the content when it's expanded.
- */
-Toggler.CSS_EXPANDED = 'toggler-expanded';
-
-/**
- * The CSS class added to the header when the content is collapsed.
- */
-Toggler.CSS_HEADER_COLLAPSED = 'toggler-header-collapsed';
-
-/**
- * The CSS class added to the header when the content is expanded.
- */
-Toggler.CSS_HEADER_EXPANDED = 'toggler-header-expanded';
 
 export default Toggler;

--- a/test/Toggler.js
+++ b/test/Toggler.js
@@ -24,12 +24,12 @@ describe('Toggler', function() {
 			});
 
 			dom.triggerEvent(toggler.header, 'click');
-			assert.ok(!dom.hasClass(toggler.content, Toggler.CSS_COLLAPSED));
-			assert.ok(dom.hasClass(toggler.content, Toggler.CSS_EXPANDED));
+			assert.ok(!dom.hasClass(toggler.content, toggler.cssCollapsed));
+			assert.ok(dom.hasClass(toggler.content, toggler.cssExpanded));
 
 			dom.triggerEvent(toggler.header, 'click');
-			assert.ok(dom.hasClass(toggler.content, Toggler.CSS_COLLAPSED));
-			assert.ok(!dom.hasClass(toggler.content, Toggler.CSS_EXPANDED));
+			assert.ok(dom.hasClass(toggler.content, toggler.cssCollapsed));
+			assert.ok(!dom.hasClass(toggler.content, toggler.cssExpanded));
 		});
 
 		it('should expand/collapse content when ENTER key is pressed on header', function() {
@@ -41,14 +41,14 @@ describe('Toggler', function() {
 			dom.triggerEvent(toggler.header, 'keydown', {
 				keyCode: 13
 			});
-			assert.ok(!dom.hasClass(toggler.content, Toggler.CSS_COLLAPSED));
-			assert.ok(dom.hasClass(toggler.content, Toggler.CSS_EXPANDED));
+			assert.ok(!dom.hasClass(toggler.content, toggler.cssCollapsed));
+			assert.ok(dom.hasClass(toggler.content, toggler.cssExpanded));
 
 			dom.triggerEvent(toggler.header, 'keydown', {
 				keyCode: 13
 			});
-			assert.ok(dom.hasClass(toggler.content, Toggler.CSS_COLLAPSED));
-			assert.ok(!dom.hasClass(toggler.content, Toggler.CSS_EXPANDED));
+			assert.ok(dom.hasClass(toggler.content, toggler.cssCollapsed));
+			assert.ok(!dom.hasClass(toggler.content, toggler.cssExpanded));
 		});
 
 		it('should expand/collapse content when SPACE key is pressed on header', function() {
@@ -60,14 +60,14 @@ describe('Toggler', function() {
 			dom.triggerEvent(toggler.header, 'keydown', {
 				keyCode: 32
 			});
-			assert.ok(!dom.hasClass(toggler.content, Toggler.CSS_COLLAPSED));
-			assert.ok(dom.hasClass(toggler.content, Toggler.CSS_EXPANDED));
+			assert.ok(!dom.hasClass(toggler.content, toggler.cssCollapsed));
+			assert.ok(dom.hasClass(toggler.content, toggler.cssExpanded));
 
 			dom.triggerEvent(toggler.header, 'keydown', {
 				keyCode: 32
 			});
-			assert.ok(dom.hasClass(toggler.content, Toggler.CSS_COLLAPSED));
-			assert.ok(!dom.hasClass(toggler.content, Toggler.CSS_EXPANDED));
+			assert.ok(dom.hasClass(toggler.content, toggler.cssCollapsed));
+			assert.ok(!dom.hasClass(toggler.content, toggler.cssExpanded));
 		});
 
 		it('should not expand/collapse content when any other key is pressed on header', function() {
@@ -79,8 +79,8 @@ describe('Toggler', function() {
 			dom.triggerEvent(toggler.header, 'keydown', {
 				keyCode: 10
 			});
-			assert.ok(dom.hasClass(toggler.content, Toggler.CSS_COLLAPSED));
-			assert.ok(!dom.hasClass(toggler.content, Toggler.CSS_EXPANDED));
+			assert.ok(dom.hasClass(toggler.content, toggler.cssCollapsed));
+			assert.ok(!dom.hasClass(toggler.content, toggler.cssExpanded));
 		});
 
 		it('should add css classes to header when content is expanded/collapsed', function() {
@@ -90,12 +90,12 @@ describe('Toggler', function() {
 			});
 
 			dom.triggerEvent(toggler.header, 'click');
-			assert.ok(!dom.hasClass(toggler.header, Toggler.CSS_HEADER_COLLAPSED));
-			assert.ok(dom.hasClass(toggler.header, Toggler.CSS_HEADER_EXPANDED));
+			assert.ok(!dom.hasClass(toggler.header, toggler.cssHeaderCollapsed));
+			assert.ok(dom.hasClass(toggler.header, toggler.cssHeaderExpanded));
 
 			dom.triggerEvent(toggler.header, 'click');
-			assert.ok(dom.hasClass(toggler.header, Toggler.CSS_HEADER_COLLAPSED));
-			assert.ok(!dom.hasClass(toggler.header, Toggler.CSS_HEADER_EXPANDED));
+			assert.ok(dom.hasClass(toggler.header, toggler.cssHeaderCollapsed));
+			assert.ok(!dom.hasClass(toggler.header, toggler.cssHeaderExpanded));
 		});
 
 		it('should not throw error if no header is given', function() {
@@ -125,16 +125,16 @@ describe('Toggler', function() {
 			var content2 = dom.toElement('#togglerContent2');
 
 			dom.triggerEvent(toggler1, 'click');
-			assert.ok(!dom.hasClass(content1, Toggler.CSS_COLLAPSED));
-			assert.ok(dom.hasClass(content1, Toggler.CSS_EXPANDED));
-			assert.ok(dom.hasClass(content2, Toggler.CSS_COLLAPSED));
-			assert.ok(!dom.hasClass(content2, Toggler.CSS_EXPANDED));
+			assert.ok(!dom.hasClass(content1, toggler.cssCollapsed));
+			assert.ok(dom.hasClass(content1, toggler.cssExpanded));
+			assert.ok(dom.hasClass(content2, toggler.cssCollapsed));
+			assert.ok(!dom.hasClass(content2, toggler.cssExpanded));
 
 			dom.triggerEvent(toggler2, 'click');
-			assert.ok(!dom.hasClass(content1, Toggler.CSS_COLLAPSED));
-			assert.ok(dom.hasClass(content1, Toggler.CSS_EXPANDED));
-			assert.ok(!dom.hasClass(content2, Toggler.CSS_COLLAPSED));
-			assert.ok(dom.hasClass(content2, Toggler.CSS_EXPANDED));
+			assert.ok(!dom.hasClass(content1, toggler.cssCollapsed));
+			assert.ok(dom.hasClass(content1, toggler.cssExpanded));
+			assert.ok(!dom.hasClass(content2, toggler.cssCollapsed));
+			assert.ok(dom.hasClass(content2, toggler.cssExpanded));
 		});
 
 		it('should use the header\'s next matched sibling as its content', function() {
@@ -149,8 +149,8 @@ describe('Toggler', function() {
 			});
 
 			dom.triggerEvent(dom.toElement('.toggler-btn'), 'click');
-			assert.ok(!dom.hasClass(dom.toElement('#togglerContent1'), Toggler.CSS_COLLAPSED));
-			assert.ok(dom.hasClass(dom.toElement('#togglerContent1'), Toggler.CSS_EXPANDED));
+			assert.ok(!dom.hasClass(dom.toElement('#togglerContent1'), toggler.cssCollapsed));
+			assert.ok(dom.hasClass(dom.toElement('#togglerContent1'), toggler.cssExpanded));
 		});
 
 		it('should use the header\'s first matched child if no sibling matches content selector', function() {
@@ -162,8 +162,8 @@ describe('Toggler', function() {
 			});
 
 			dom.triggerEvent(dom.toElement('.toggler-btn'), 'click');
-			assert.ok(!dom.hasClass(dom.toElement('.toggler-content'), Toggler.CSS_COLLAPSED));
-			assert.ok(dom.hasClass(dom.toElement('.toggler-content'), Toggler.CSS_EXPANDED));
+			assert.ok(!dom.hasClass(dom.toElement('.toggler-content'), toggler.cssCollapsed));
+			assert.ok(dom.hasClass(dom.toElement('.toggler-content'), toggler.cssExpanded));
 		});
 
 		it('should use any matched element if no matching header sibling or child is found', function() {
@@ -176,8 +176,8 @@ describe('Toggler', function() {
 			});
 
 			dom.triggerEvent(dom.toElement('.toggler-btn'), 'click');
-			assert.ok(!dom.hasClass(dom.toElement('.toggler-content'), Toggler.CSS_COLLAPSED));
-			assert.ok(dom.hasClass(dom.toElement('.toggler-content'), Toggler.CSS_EXPANDED));
+			assert.ok(!dom.hasClass(dom.toElement('.toggler-content'), toggler.cssCollapsed));
+			assert.ok(dom.hasClass(dom.toElement('.toggler-content'), toggler.cssExpanded));
 		});
 
 		describe('Container', function() {
@@ -200,12 +200,12 @@ describe('Toggler', function() {
 				});
 
 				dom.triggerEvent(dom.toElement('.toggler-btn'), 'click');
-				assert.ok(dom.hasClass(dom.toElement('.toggler-content'), Toggler.CSS_COLLAPSED));
-				assert.ok(!dom.hasClass(dom.toElement('.toggler-content'), Toggler.CSS_EXPANDED));
+				assert.ok(dom.hasClass(dom.toElement('.toggler-content'), toggler.cssCollapsed));
+				assert.ok(!dom.hasClass(dom.toElement('.toggler-content'), toggler.cssExpanded));
 
 				dom.triggerEvent(dom.toElement('.container .toggler-btn'), 'click');
-				assert.ok(!dom.hasClass(dom.toElement('.container .toggler-content'), Toggler.CSS_COLLAPSED));
-				assert.ok(dom.hasClass(dom.toElement('.container .toggler-content'), Toggler.CSS_EXPANDED));
+				assert.ok(!dom.hasClass(dom.toElement('.container .toggler-content'), toggler.cssCollapsed));
+				assert.ok(dom.hasClass(dom.toElement('.container .toggler-content'), toggler.cssExpanded));
 			});
 
 			it('should only work for header elements that are inside container given as element', function() {
@@ -216,12 +216,12 @@ describe('Toggler', function() {
 				});
 
 				dom.triggerEvent(dom.toElement('.toggler-btn'), 'click');
-				assert.ok(dom.hasClass(dom.toElement('.toggler-content'), Toggler.CSS_COLLAPSED));
-				assert.ok(!dom.hasClass(dom.toElement('.toggler-content'), Toggler.CSS_EXPANDED));
+				assert.ok(dom.hasClass(dom.toElement('.toggler-content'), toggler.cssCollapsed));
+				assert.ok(!dom.hasClass(dom.toElement('.toggler-content'), toggler.cssExpanded));
 
 				dom.triggerEvent(dom.toElement('.container .toggler-btn'), 'click');
-				assert.ok(!dom.hasClass(dom.toElement('.container .toggler-content'), Toggler.CSS_COLLAPSED));
-				assert.ok(dom.hasClass(dom.toElement('.container .toggler-content'), Toggler.CSS_EXPANDED));
+				assert.ok(!dom.hasClass(dom.toElement('.container .toggler-content'), toggler.cssCollapsed));
+				assert.ok(dom.hasClass(dom.toElement('.container .toggler-content'), toggler.cssExpanded));
 			});
 		});
 	});


### PR DESCRIPTION
We'd like to be able to customize the css classes used by this component.