### PR TITLE
Added expand and collapse methods

### DIFF
--- a/src/Toggler.js
+++ b/src/Toggler.js
@@ -95,19 +95,43 @@ class Toggler extends State {
 	}
 
 	/**
+	* Manually expand the content's visibility.
+	* @param {!Element} header
+	* @param {!Element} header
+	*/
+	expand(header, content) {
+		dom.addClasses(content, this.expandedClasses);
+		dom.removeClasses(content, this.collapsedClasses);
+		dom.addClasses(header, this.headerExpandedClasses);
+		dom.removeClasses(header, this.headerCollapsedClasses);
+	}
+
+	/**
+	* Manually collapse the content's visibility.
+	* @param {!Element} header
+	* @param {!Element} header
+	*/
+	collapse(header, content) {
+		dom.removeClasses(content, this.expandedClasses);
+		dom.addClasses(content, this.collapsedClasses);
+		dom.removeClasses(header, this.headerExpandedClasses);
+		dom.addClasses(header, this.headerCollapsedClasses);
+	}
+
+	/**
 	 * Toggles the content's visibility.
+	 * @param {!Element} header
 	 */
 	toggle(header) {
+		if (header === undefined) {
+			header = this.header;
+		}
 		var content = this.getContentElement_(header);
-		dom.toggleClasses(content, this.expandedClasses);
-		dom.toggleClasses(content, this.collapsedClasses);
-
 		if (dom.hasClass(content, this.expandedClasses)) {
-			dom.addClasses(header, this.headerExpandedClasses);
-			dom.removeClasses(header, this.headerCollapsedClasses);
-		} else {
-			dom.removeClasses(header, this.headerExpandedClasses);
-			dom.addClasses(header, this.headerCollapsedClasses);
+			this.collapse(header, content);
+		}
+		else {
+			this.expand(header, content);
 		}
 	}
 }

--- a/src/Toggler.js
+++ b/src/Toggler.js
@@ -97,9 +97,9 @@ class Toggler extends State {
 	/**
 	* Manually expand the content's visibility.
 	* @param {!Element} header
-	* @param {!Element} header
 	*/
-	expand(header, content) {
+	expand(header = this.header) {
+		var content = this.getContentElement_(header);
 		dom.addClasses(content, this.expandedClasses);
 		dom.removeClasses(content, this.collapsedClasses);
 		dom.addClasses(header, this.headerExpandedClasses);
@@ -109,9 +109,9 @@ class Toggler extends State {
 	/**
 	* Manually collapse the content's visibility.
 	* @param {!Element} header
-	* @param {!Element} header
 	*/
-	collapse(header, content) {
+	collapse(header = this.header) {
+		var content = this.getContentElement_(header);
 		dom.removeClasses(content, this.expandedClasses);
 		dom.addClasses(content, this.collapsedClasses);
 		dom.removeClasses(header, this.headerExpandedClasses);
@@ -122,16 +122,11 @@ class Toggler extends State {
 	 * Toggles the content's visibility.
 	 * @param {!Element} header
 	 */
-	toggle(header) {
-		if (header === undefined) {
-			header = this.header;
-		}
-		var content = this.getContentElement_(header);
-		if (dom.hasClass(content, this.expandedClasses)) {
-			this.collapse(header, content);
-		}
-		else {
-			this.expand(header, content);
+	toggle(header = this.header) {
+		if (dom.hasClass(header, this.headerExpandedClasses)) {
+			this.collapse(header);
+		} else {
+			this.expand(header);
 		}
 	}
 }

--- a/src/Toggler.js
+++ b/src/Toggler.js
@@ -30,6 +30,30 @@ class Toggler extends State {
 	}
 
 	/**
+	* Manually collapse the content's visibility.
+	* @param {!Element} header
+	*/
+	collapse(header = this.header) {
+		var content = this.getContentElement_(header);
+		dom.removeClasses(content, this.expandedClasses);
+		dom.addClasses(content, this.collapsedClasses);
+		dom.removeClasses(header, this.headerExpandedClasses);
+		dom.addClasses(header, this.headerCollapsedClasses);
+	}
+
+	/**
+	* Manually expand the content's visibility.
+	* @param {!Element} header
+	*/
+	expand(header = this.header) {
+		var content = this.getContentElement_(header);
+		dom.addClasses(content, this.expandedClasses);
+		dom.removeClasses(content, this.collapsedClasses);
+		dom.addClasses(header, this.headerExpandedClasses);
+		dom.removeClasses(header, this.headerCollapsedClasses);
+	}
+
+	/**
 	 * Gets the content to be toggled by the given header element.
 	 * @param {!Element} header
 	 * @protected
@@ -95,30 +119,6 @@ class Toggler extends State {
 	}
 
 	/**
-	* Manually expand the content's visibility.
-	* @param {!Element} header
-	*/
-	expand(header = this.header) {
-		var content = this.getContentElement_(header);
-		dom.addClasses(content, this.expandedClasses);
-		dom.removeClasses(content, this.collapsedClasses);
-		dom.addClasses(header, this.headerExpandedClasses);
-		dom.removeClasses(header, this.headerCollapsedClasses);
-	}
-
-	/**
-	* Manually collapse the content's visibility.
-	* @param {!Element} header
-	*/
-	collapse(header = this.header) {
-		var content = this.getContentElement_(header);
-		dom.removeClasses(content, this.expandedClasses);
-		dom.addClasses(content, this.collapsedClasses);
-		dom.removeClasses(header, this.headerExpandedClasses);
-		dom.addClasses(header, this.headerCollapsedClasses);
-	}
-
-	/**
 	 * Toggles the content's visibility.
 	 * @param {!Element} header
 	 */
@@ -135,6 +135,14 @@ class Toggler extends State {
  * State configuration.
  */
 Toggler.STATE = {
+	/**
+	 * The CSS classes added to the content when it's collapsed.
+	 */
+	collapsedClasses: {
+		validator: core.isString,
+		value: 'toggler-collapsed'
+	},
+
 	/**
 	 * The element where the header/content selectors will be looked for.
 	 * @type {string|!Element}
@@ -154,28 +162,19 @@ Toggler.STATE = {
 	},
 
 	/**
-	 * The element that should be trigger toggling.
-	 * @type {string|!Element}
-	 */
-	header: {
-		validator: value => core.isString(value) || core.isElement(value)
-	},
-
-	/**
-	 * The CSS classes added to the content when it's collapsed.
-	 */
-	collapsedClasses: {
-		validator: core.isString,
-		value: 'toggler-collapsed'
-	},
-
-
-	/**
 	 * The CSS classes added to the content when it's expanded.
 	 */
 	expandedClasses: {
 		validator: core.isString,
 		value: 'toggler-expanded'
+	},
+
+	/**
+	 * The element that should be trigger toggling.
+	 * @type {string|!Element}
+	 */
+	header: {
+		validator: value => core.isString(value) || core.isElement(value)
 	},
 
 	/**

--- a/test/Toggler.js
+++ b/test/Toggler.js
@@ -105,6 +105,25 @@ describe('Toggler', function() {
 				});
 			});
 		});
+
+		it('should expand/collapse content by calling the publish method', function() {
+			toggler = new Toggler({
+				content: dom.toElement('.toggler-content'),
+				header: dom.toElement('.toggler-btn')
+			});
+
+			toggler.expand();
+			assert.ok(!dom.hasClass(toggler.content, toggler.collapsedClasses));
+			assert.ok(dom.hasClass(toggler.content, toggler.expandedClasses));
+			assert.ok(!dom.hasClass(toggler.header, toggler.headerCollapsedClasses));
+			assert.ok(dom.hasClass(toggler.header, toggler.headerExpandedClasses));
+
+			toggler.collapse();
+			assert.ok(dom.hasClass(toggler.content, toggler.collapsedClasses));
+			assert.ok(!dom.hasClass(toggler.content, toggler.expandedClasses));
+			assert.ok(dom.hasClass(toggler.header, toggler.headerCollapsedClasses));
+			assert.ok(!dom.hasClass(toggler.header, toggler.headerExpandedClasses));
+		});
 	});
 
 	describe('Delegate Toggler', function() {
@@ -135,6 +154,56 @@ describe('Toggler', function() {
 			assert.ok(dom.hasClass(content1, toggler.expandedClasses));
 			assert.ok(!dom.hasClass(content2, toggler.collapsedClasses));
 			assert.ok(dom.hasClass(content2, toggler.expandedClasses));
+		});
+
+		it('should expand the appropriate content when an element matching header by calling the publich method', function() {
+			dom.enterDocument('<button id="toggler1" class="toggler-btn"></button>');
+			dom.enterDocument('<div id="togglerContent1" class="toggler-content toggler-collapsed"></div>');
+			dom.enterDocument('<button id="toggler2" class="toggler-btn"></button>');
+			dom.enterDocument('<div id="togglerContent2" class="toggler-content toggler-collapsed"></div>');
+
+			toggler = new Toggler({
+				content: '.toggler-content',
+				header: '.toggler-btn'
+			});
+
+			var toggler1 = dom.toElement('#toggler1');
+			var toggler2 = dom.toElement('#toggler2');
+			var content1 = dom.toElement('#togglerContent1');
+			var content2 = dom.toElement('#togglerContent2');
+
+			toggler.expand(toggler1);
+			assert.ok(!dom.hasClass(content1, toggler.collapsedClasses));
+			assert.ok(dom.hasClass(content1, toggler.expandedClasses));
+
+			toggler.expand(toggler2);
+			assert.ok(!dom.hasClass(content2, toggler.collapsedClasses));
+			assert.ok(dom.hasClass(content2, toggler.expandedClasses));
+		});
+
+		it('should collapse the appropriate content when an element matching header by calling the publich method', function() {
+			dom.enterDocument('<button id="toggler1" class="toggler-btn"></button>');
+			dom.enterDocument('<div id="togglerContent1" class="toggler-content toggler-collapsed"></div>');
+			dom.enterDocument('<button id="toggler2" class="toggler-btn"></button>');
+			dom.enterDocument('<div id="togglerContent2" class="toggler-content toggler-collapsed"></div>');
+
+			toggler = new Toggler({
+				content: '.toggler-content',
+				header: '.toggler-btn'
+			});
+
+			var toggler1 = dom.toElement('#toggler1');
+			var toggler2 = dom.toElement('#toggler2');
+			var content1 = dom.toElement('#togglerContent1');
+			var content2 = dom.toElement('#togglerContent2');
+
+			toggler.collapse(toggler1);
+			assert.ok(dom.hasClass(content1, toggler.collapsedClasses));
+			assert.ok(!dom.hasClass(content1, toggler.expandedClasses));
+
+			toggler.collapse(toggler2);
+			assert.ok(dom.hasClass(content2, toggler.collapsedClasses));
+			assert.ok(!dom.hasClass(content2, toggler.expandedClasses));
 		});
 
 		it('should use the header\'s next matched sibling as its content', function() {


### PR DESCRIPTION
In WeDeploy.com, we needed some way to manually collapse our content once we finished navigation. As such, I'm currently proposing two methods that either expand or collapse the header/content.