### PR TITLE
Header may be string

### DIFF
--- a/src/Toggler.js
+++ b/src/Toggler.js
@@ -68,9 +68,11 @@ class Toggler extends State {
 			return content;
 		}
 
-		content = header.querySelector(this.content);
-		if (content) {
-			return content;
+		if (core.isElement(header)){
+			content = header.querySelector(this.content);
+			if (content) {
+				return content;
+			}
 		}
 
 		return this.container.querySelector(this.content);


### PR DESCRIPTION
Hi @fernandosouza ,

I remember why I put this check in. I realized that `header` may be a string, and it will error out at the `header.querySelector(...)` function call. I am currently getting this error when I call `collapse()` in `WeDeploy/Console`.  The first two checks `core.isElement(this.content)` and `dom.next(header, this.content)` both return `null` as `this.content` is a string (and so is not an element), and `this.content` is not a sibling of `header`. 

Thanks!

@eduardolundgren 