### PR TITLE
Adds toggle all elements support

### DIFF
--- a/src/Toggler.js
+++ b/src/Toggler.js
@@ -33,30 +33,26 @@ class Toggler extends State {
 	* Manually collapse the content's visibility.
 	* @param {string|!Element} header
 	*/
-	collapse(header = this.header) {
-		let content = this.getContentElement_(header);
-		if (!core.isElement(header)) {
-			header = this.getHeaderElements_(header);
-		}
+	collapse(header) {
+		let headerElements = this.getHeaderElements_(header);
+		let content = this.getContentElement_(headerElements);
 		dom.removeClasses(content, this.expandedClasses);
 		dom.addClasses(content, this.collapsedClasses);
-		dom.removeClasses(header, this.headerExpandedClasses);
-		dom.addClasses(header, this.headerCollapsedClasses);
+		dom.removeClasses(headerElements, this.headerExpandedClasses);
+		dom.addClasses(headerElements, this.headerCollapsedClasses);
 	}
 
 	/**
 	* Manually expand the content's visibility.
 	* @param {string|!Element} header
 	*/
-	expand(header = this.header) {
-		let content = this.getContentElement_(header);
-		if (!core.isElement(header)) {
-			header = this.getHeaderElements_(header);
-		}
+	expand(header) {
+		let headerElements = this.getHeaderElements_(header);
+		let content = this.getContentElement_(headerElements);
 		dom.addClasses(content, this.expandedClasses);
 		dom.removeClasses(content, this.collapsedClasses);
-		dom.addClasses(header, this.headerExpandedClasses);
-		dom.removeClasses(header, this.headerCollapsedClasses);
+		dom.addClasses(headerElements, this.headerExpandedClasses);
+		dom.removeClasses(headerElements, this.headerCollapsedClasses);
 	}
 
 	/**
@@ -91,7 +87,10 @@ class Toggler extends State {
 	 * @returns {!Nodelist}
 	 * @protected
 	 */
-	getHeaderElements_(header) {
+	getHeaderElements_(header = this.header) {
+		if (core.isElement(header) || core.isElement(header[0])) {
+			return header;
+		}
 		return this.container.querySelectorAll(header);
 	}
 
@@ -154,11 +153,12 @@ class Toggler extends State {
 	 * Toggles the content's visibility.
 	 * @param {string|!Element} header
 	 */
-	toggle(header = this.header) {
-		if (this.hasExpanded_(header)) {
-			this.collapse(header);
+	toggle(header) {
+		let headerElements = this.getHeaderElements_(header);
+		if (this.hasExpanded_(headerElements)) {
+			this.collapse(headerElements);
 		} else {
-			this.expand(header);
+			this.expand(headerElements);
 		}
 	}
 }

--- a/src/Toggler.js
+++ b/src/Toggler.js
@@ -31,10 +31,13 @@ class Toggler extends State {
 
 	/**
 	* Manually collapse the content's visibility.
-	* @param {!Element} header
+	* @param {string|!Element} header
 	*/
 	collapse(header = this.header) {
-		var content = this.getContentElement_(header);
+		let content = this.getContentElement_(header);
+		if (!core.isElement(header)) {
+			header = this.getHeaderElements_(header);
+		}
 		dom.removeClasses(content, this.expandedClasses);
 		dom.addClasses(content, this.collapsedClasses);
 		dom.removeClasses(header, this.headerExpandedClasses);
@@ -43,10 +46,13 @@ class Toggler extends State {
 
 	/**
 	* Manually expand the content's visibility.
-	* @param {!Element} header
+	* @param {string|!Element} header
 	*/
 	expand(header = this.header) {
-		var content = this.getContentElement_(header);
+		let content = this.getContentElement_(header);
+		if (!core.isElement(header)) {
+			header = this.getHeaderElements_(header);
+		}
 		dom.addClasses(content, this.expandedClasses);
 		dom.removeClasses(content, this.collapsedClasses);
 		dom.addClasses(header, this.headerExpandedClasses);
@@ -56,6 +62,7 @@ class Toggler extends State {
 	/**
 	 * Gets the content to be toggled by the given header element.
 	 * @param {!Element} header
+	 * @returns {!Element}
 	 * @protected
 	 */
 	getContentElement_(header) {
@@ -68,14 +75,24 @@ class Toggler extends State {
 			return content;
 		}
 
-		if (core.isElement(header)){
+		if (core.isElement(header)) {
 			content = header.querySelector(this.content);
 			if (content) {
 				return content;
 			}
 		}
 
-		return this.container.querySelector(this.content);
+		return this.container.querySelectorAll(this.content);
+	}
+
+	/**
+	 * Gets the header elements by giving a selector.
+	 * @param {string} header
+	 * @returns {!Nodelist}
+	 * @protected
+	 */
+	getHeaderElements_(header) {
+		return this.container.querySelectorAll(header);
 	}
 
 	/**
@@ -97,6 +114,19 @@ class Toggler extends State {
 			this.toggle(event.delegateTarget || event.currentTarget);
 			event.preventDefault();
 		}
+	}
+
+	/**
+	 * Checks if there is any expanded header in the component context.
+	 * @param {string|!Element} event
+	 * @param {boolean}
+	 * @protected
+	 */
+	hasExpanded_(header) {
+		if (core.isElement(header)) {
+			return dom.hasClass(header, this.headerExpandedClasses);
+		}
+		return !!this.container.querySelectorAll(`.${this.headerExpandedClasses}`).length;
 	}
 
 	/**
@@ -122,10 +152,10 @@ class Toggler extends State {
 
 	/**
 	 * Toggles the content's visibility.
-	 * @param {!Element} header
+	 * @param {string|!Element} header
 	 */
 	toggle(header = this.header) {
-		if (dom.hasClass(header, this.headerExpandedClasses)) {
+		if (this.hasExpanded_(header)) {
 			this.collapse(header);
 		} else {
 			this.expand(header);

--- a/src/Toggler.js
+++ b/src/Toggler.js
@@ -68,9 +68,11 @@ class Toggler extends State {
 			return content;
 		}
 
-		content = header.querySelector(this.content);
-		if (content) {
-			return content;
+		if (core.isElement(header)){
+			content = header.querySelector(this.content);
+			if (content) {
+				return content;
+			}
 		}
 
 		return this.container.querySelector(this.content);

--- a/test/Toggler.js
+++ b/test/Toggler.js
@@ -106,7 +106,7 @@ describe('Toggler', function() {
 			});
 		});
 
-		it('should expand/collapse content by calling the publish method', function() {
+		it('should expand/collapse content by calling the public method', function() {
 			toggler = new Toggler({
 				content: dom.toElement('.toggler-content'),
 				header: dom.toElement('.toggler-btn')
@@ -204,6 +204,35 @@ describe('Toggler', function() {
 			toggler.collapse(toggler2);
 			assert.ok(dom.hasClass(content2, toggler.collapsedClasses));
 			assert.ok(!dom.hasClass(content2, toggler.expandedClasses));
+		});
+
+		it('should toggle all elements by calling the public methods without arguments', function() {
+			dom.enterDocument('<button id="toggler1" class="toggler-btn"></button>');
+			dom.enterDocument('<div id="togglerContent1" class="toggler-content toggler-collapsed"></div>');
+			dom.enterDocument('<button id="toggler2" class="toggler-btn"></button>');
+			dom.enterDocument('<div id="togglerContent2" class="toggler-content toggler-collapsed"></div>');
+
+			toggler = new Toggler({
+				content: '.toggler-content',
+				header: '.toggler-btn'
+			});
+
+			var toggler1 = dom.toElement('#toggler1');
+			var toggler2 = dom.toElement('#toggler2');
+			var content1 = dom.toElement('#togglerContent1');
+			var content2 = dom.toElement('#togglerContent2');
+
+			toggler.toggle();
+			assert.ok(dom.hasClass(content1, toggler.expandedClasses));
+			assert.ok(dom.hasClass(content2, toggler.expandedClasses));
+			assert.ok(dom.hasClass(toggler1, toggler.headerExpandedClasses));
+			assert.ok(dom.hasClass(toggler2, toggler.headerExpandedClasses));
+
+			toggler.toggle();
+			assert.ok(dom.hasClass(content1, toggler.collapsedClasses));
+			assert.ok(dom.hasClass(content2, toggler.collapsedClasses));
+			assert.ok(dom.hasClass(toggler1, toggler.headerCollapsedClasses));
+			assert.ok(dom.hasClass(toggler2, toggler.headerCollapsedClasses));
 		});
 
 		it('should use the header\'s next matched sibling as its content', function() {


### PR DESCRIPTION
This adds a way to use `toggle()`, `expand()` and `collapse()` with no arguments. It might be helpful to manipulate all elements covered by a metal-toggle instance at once.

This use case was described by @NolanChan in `WeDeploy/Console`.
