### PR TITLE
Emit events from toggler

### DIFF
--- a/karma-saucelabs.conf.js
+++ b/karma-saucelabs.conf.js
@@ -102,6 +102,7 @@ module.exports = function(config) {
 			'karma-chai',
 			'karma-chrome-launcher',
 			'karma-mocha',
+			'karma-sinon',
 			'karma-webpack',
 			karmaSauceLauncher
 		],

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -4,7 +4,7 @@ module.exports = function(config) {
 	config.set({
 		browsers: ['Chrome'],
 
-		frameworks: ['mocha', 'chai'],
+		frameworks: ['mocha', 'chai', 'sinon'],
 
 		files: [
 			{
@@ -19,6 +19,7 @@ module.exports = function(config) {
 			'karma-chai',
 			'karma-chrome-launcher',
 			'karma-mocha',
+			'karma-sinon',
 			'karma-webpack'
 		],
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -3305,6 +3305,15 @@
         "mime-types": "2.1.17"
       }
     },
+    "formatio": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/formatio/-/formatio-1.2.0.tgz",
+      "integrity": "sha1-87IWfZBoxGmKjVH092CjmlTYGOs=",
+      "dev": true,
+      "requires": {
+        "samsam": "1.3.0"
+      }
+    },
     "fs-access": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/fs-access/-/fs-access-1.0.1.tgz",
@@ -4100,14 +4109,6 @@
             }
           }
         },
-        "string_decoder": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "safe-buffer": "5.0.1"
-          }
-        },
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
@@ -4116,6 +4117,14 @@
             "code-point-at": "1.1.0",
             "is-fullwidth-code-point": "1.0.0",
             "strip-ansi": "3.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
           }
         },
         "stringstream": {
@@ -5620,6 +5629,12 @@
         }
       }
     },
+    "just-extend": {
+      "version": "1.1.27",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-1.1.27.tgz",
+      "integrity": "sha512-mJVp13Ix6gFo3SBAy9U/kL+oeZqzlYYYLQBwXVBlVzIsZwBqGREnOro24oC/8s8aox+rJhtZ2DiQof++IrkA+g==",
+      "dev": true
+    },
     "karma": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/karma/-/karma-1.1.0.tgz",
@@ -5705,6 +5720,12 @@
         "saucelabs": "1.4.0",
         "wd": "1.4.1"
       }
+    },
+    "karma-sinon": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/karma-sinon/-/karma-sinon-1.0.5.tgz",
+      "integrity": "sha1-TjRD8oMP3s/2JNN0cWPxIX2qKpo=",
+      "dev": true
     },
     "karma-webpack": {
       "version": "2.0.6",
@@ -6172,6 +6193,12 @@
         "lodash._root": "3.0.1"
       }
     },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
+      "dev": true
+    },
     "lodash.isarguments": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
@@ -6416,6 +6443,12 @@
         "chalk": "1.1.3",
         "loglevel": "1.6.0"
       }
+    },
+    "lolex": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.3.1.tgz",
+      "integrity": "sha512-mQuW55GhduF3ppo+ZRUTz1PRjEh1hS5BbqU7d8D0ez2OKxHDod7StPPeAVKisZR5aLkHZjdGWSL42LSONUJsZw==",
+      "dev": true
     },
     "longest": {
       "version": "1.0.1",
@@ -6942,6 +6975,27 @@
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.4.9.tgz",
       "integrity": "sha1-kuRrbbU8fkIe1koryU8IvnYw3z8=",
       "dev": true
+    },
+    "nise": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-1.2.0.tgz",
+      "integrity": "sha512-q9jXh3UNsMV28KeqI43ILz5+c3l+RiNW8mhurEwCKckuHQbL+hTJIKKTiUlCPKlgQ/OukFvSnKB/Jk3+sFbkGA==",
+      "dev": true,
+      "requires": {
+        "formatio": "1.2.0",
+        "just-extend": "1.1.27",
+        "lolex": "1.6.0",
+        "path-to-regexp": "1.7.0",
+        "text-encoding": "0.6.4"
+      },
+      "dependencies": {
+        "lolex": {
+          "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/lolex/-/lolex-1.6.0.tgz",
+          "integrity": "sha1-OpoCg0UqR9dDnnJzG54H1zhuSfY=",
+          "dev": true
+        }
+      }
     },
     "node-gyp": {
       "version": "3.6.2",
@@ -7482,6 +7536,23 @@
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
       "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
       "dev": true
+    },
+    "path-to-regexp": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
+      "integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
+      "dev": true,
+      "requires": {
+        "isarray": "0.0.1"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
+        }
+      }
     },
     "path-type": {
       "version": "2.0.0",
@@ -8839,6 +8910,12 @@
       "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
       "dev": true
     },
+    "samsam": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.3.0.tgz",
+      "integrity": "sha512-1HwIYD/8UlOtFS3QO3w7ey+SdSDFE4HRNLZoZRYVQefrOY3l17epswImeB1ijgJFQJodIaHcwkp3r/myBjFVbg==",
+      "dev": true
+    },
     "sass-graph": {
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/sass-graph/-/sass-graph-2.2.4.tgz",
@@ -9175,6 +9252,38 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
       "dev": true
+    },
+    "sinon": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-4.1.2.tgz",
+      "integrity": "sha512-5uLBZPdCWl59Lpbf45ygKj7Z0LVol+ftBe7RDIXOQV/sF58pcFmbK8raA7bt6eljNuGnvBP+/ZxlicVn0emDjA==",
+      "dev": true,
+      "requires": {
+        "diff": "3.3.1",
+        "formatio": "1.2.0",
+        "lodash.get": "4.4.2",
+        "lolex": "2.3.1",
+        "nise": "1.2.0",
+        "supports-color": "4.5.0",
+        "type-detect": "4.0.5"
+      },
+      "dependencies": {
+        "has-flag": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "dev": true,
+          "requires": {
+            "has-flag": "2.0.0"
+          }
+        }
+      }
     },
     "slash": {
       "version": "1.0.0",
@@ -9554,15 +9663,6 @@
       "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
       "dev": true
     },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
-    },
     "string-width": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
@@ -9594,6 +9694,15 @@
             "ansi-regex": "3.0.0"
           }
         }
+      }
+    },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.1"
       }
     },
     "stringify-object": {
@@ -9790,6 +9899,12 @@
         "merge-stream": "1.0.1",
         "through2": "2.0.3"
       }
+    },
+    "text-encoding": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
+      "integrity": "sha1-45mpgiV6J22uQou5KEXLcb3CbRk=",
+      "dev": true
     },
     "text-table": {
       "version": "0.2.0",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "karma-chrome-launcher": "^2.2.0",
     "karma-mocha": "^1.3.0",
     "karma-sauce-launcher": "^1.1.0",
+    "karma-sinon": "^1.0.5",
     "karma-webpack": "^2.0.6",
     "lint-staged": "^5.0.0",
     "metal-tools-soy": "^4.2.6",
@@ -59,6 +60,7 @@
     "node-sass": "^4.5.3",
     "prettier-eslint-cli": "^4.4.0",
     "sass-loader": "^6.0.6",
+    "sinon": "^4.1.2",
     "style-loader": "^0.18.2",
     "webpack": "^3.5.5"
   },

--- a/src/Toggler.js
+++ b/src/Toggler.js
@@ -36,6 +36,10 @@ class Toggler extends State {
 	collapse(header) {
 		let headerElements = this.getHeaderElements_(header);
 		let content = this.getContentElement_(headerElements);
+
+		this.emit('headerToggled', {headerElements, content});
+		this.emit('headerCollapsed', {headerElements, content});
+
 		dom.removeClasses(content, this.expandedClasses);
 		dom.addClasses(content, this.collapsedClasses);
 		dom.removeClasses(headerElements, this.headerExpandedClasses);
@@ -51,6 +55,10 @@ class Toggler extends State {
 	expand(header) {
 		let headerElements = this.getHeaderElements_(header);
 		let content = this.getContentElement_(headerElements);
+
+		this.emit('headerToggled', {headerElements, content});
+		this.emit('headerExpanded', {headerElements, content});
+
 		dom.addClasses(content, this.expandedClasses);
 		dom.removeClasses(content, this.collapsedClasses);
 		dom.addClasses(headerElements, this.headerExpandedClasses);

--- a/test/Toggler.js
+++ b/test/Toggler.js
@@ -20,10 +20,7 @@ describe('Toggler', function() {
 		});
 
 		it('should expand/collapse content when header is clicked', function() {
-			toggler = new Toggler({
-				content: dom.toElement('.toggler-content'),
-				header: dom.toElement('.toggler-btn'),
-			});
+			createToggler();
 
 			dom.triggerEvent(toggler.header, 'click');
 			assert.ok(!dom.hasClass(toggler.content, toggler.collapsedClasses));
@@ -39,10 +36,7 @@ describe('Toggler', function() {
 		});
 
 		it('should expand/collapse content when ENTER key is pressed on header', function() {
-			toggler = new Toggler({
-				content: dom.toElement('.toggler-content'),
-				header: dom.toElement('.toggler-btn'),
-			});
+			createToggler();
 
 			dom.triggerEvent(toggler.header, 'keydown', {
 				keyCode: 13,
@@ -58,10 +52,7 @@ describe('Toggler', function() {
 		});
 
 		it('should expand/collapse content when SPACE key is pressed on header', function() {
-			toggler = new Toggler({
-				content: dom.toElement('.toggler-content'),
-				header: dom.toElement('.toggler-btn'),
-			});
+			createToggler();
 
 			dom.triggerEvent(toggler.header, 'keydown', {
 				keyCode: 32,
@@ -77,10 +68,7 @@ describe('Toggler', function() {
 		});
 
 		it('should not expand/collapse content when any other key is pressed on header', function() {
-			toggler = new Toggler({
-				content: dom.toElement('.toggler-content'),
-				header: dom.toElement('.toggler-btn'),
-			});
+			createToggler();
 
 			dom.triggerEvent(toggler.header, 'keydown', {
 				keyCode: 10,
@@ -90,10 +78,7 @@ describe('Toggler', function() {
 		});
 
 		it('should add css classes to header when content is expanded/collapsed', function() {
-			toggler = new Toggler({
-				content: dom.toElement('.toggler-content'),
-				header: dom.toElement('.toggler-btn'),
-			});
+			createToggler();
 
 			dom.triggerEvent(toggler.header, 'click');
 			assert.ok(!dom.hasClass(toggler.header, toggler.headerCollapsedClasses));
@@ -113,10 +98,7 @@ describe('Toggler', function() {
 		});
 
 		it('should expand/collapse content by calling the public method', function() {
-			toggler = new Toggler({
-				content: dom.toElement('.toggler-content'),
-				header: dom.toElement('.toggler-btn'),
-			});
+			createToggler();
 
 			toggler.expand();
 			assert.ok(!dom.hasClass(toggler.content, toggler.collapsedClasses));
@@ -129,6 +111,49 @@ describe('Toggler', function() {
 			assert.ok(!dom.hasClass(toggler.content, toggler.expandedClasses));
 			assert.ok(dom.hasClass(toggler.header, toggler.headerCollapsedClasses));
 			assert.ok(!dom.hasClass(toggler.header, toggler.headerExpandedClasses));
+		});
+
+		it('should fire events when the header is toggled', function() {
+			createToggler();
+
+			const listener = sinon.stub();
+
+			toggler.on('headerToggled', listener);
+
+			dom.triggerEvent(toggler.header, 'click');
+			dom.triggerEvent(toggler.header, 'click');
+
+			assert.equal(listener.callCount, 2);
+			assert.equal(listener.getCall(0).args[1].type, 'headerToggled');
+			assert.equal(listener.getCall(1).args[1].type, 'headerToggled');
+		});
+
+		it('should fire an event when the header is expanded', function() {
+			createToggler();
+
+			const listener = sinon.stub();
+
+			toggler.on('headerExpanded', listener);
+
+			dom.triggerEvent(toggler.header, 'click');
+			dom.triggerEvent(toggler.header, 'click');
+
+			assert.equal(listener.callCount, 1);
+			assert.equal(listener.getCall(0).args[1].type, 'headerExpanded');
+		});
+
+		it('should fire an event when the header is collapsed', function() {
+			createToggler();
+
+			const listener = sinon.stub();
+
+			toggler.on('headerCollapsed', listener);
+
+			dom.triggerEvent(toggler.header, 'click');
+			dom.triggerEvent(toggler.header, 'click');
+
+			assert.equal(listener.callCount, 1);
+			assert.equal(listener.getCall(0).args[1].type, 'headerCollapsed');
 		});
 	});
 
@@ -205,10 +230,7 @@ describe('Toggler', function() {
 				'<div id="togglerContent2" class="toggler-content toggler-collapsed"></div>'
 			);
 
-			toggler = new Toggler({
-				content: '.toggler-content',
-				header: '.toggler-btn',
-			});
+			createToggler();
 
 			let toggler1 = dom.toElement('#toggler1');
 			let toggler2 = dom.toElement('#toggler2');
@@ -267,10 +289,7 @@ describe('Toggler', function() {
 				'<div id="togglerContent2" class="toggler-content toggler-collapsed"></div>'
 			);
 
-			toggler = new Toggler({
-				content: '.toggler-content',
-				header: '.toggler-btn',
-			});
+			createToggler();
 
 			dom.triggerEvent(dom.toElement('.toggler-btn'), 'click');
 			assert.ok(
@@ -289,10 +308,7 @@ describe('Toggler', function() {
 				'<div class="toggler-btn"><div class="toggler-content toggler-collapsed"></div></div>'
 			);
 
-			toggler = new Toggler({
-				content: '.toggler-content',
-				header: '.toggler-btn',
-			});
+			createToggler();
 
 			dom.triggerEvent(dom.toElement('.toggler-btn'), 'click');
 			assert.ok(
@@ -312,10 +328,7 @@ describe('Toggler', function() {
 				'<div><div class="toggler-content toggler-collapsed"></div></div>'
 			);
 
-			toggler = new Toggler({
-				content: '.toggler-content',
-				header: '.toggler-btn',
-			});
+			createToggler();
 
 			dom.triggerEvent(dom.toElement('.toggler-btn'), 'click');
 			assert.ok(
@@ -416,4 +429,11 @@ describe('Toggler', function() {
 			});
 		});
 	});
+
+	function createToggler() {
+		toggler = new Toggler({
+			content: dom.toElement('.toggler-content'),
+			header: dom.toElement('.toggler-btn'),
+		});
+	}
 });


### PR DESCRIPTION
This change to metal-toggler enables developers to respond to changes to a toggler’s state — e.g. when it expands or collapses.

For example, upon toggling a site menu, I may want to (un)freeze or unfreeze scrolling, (de)activate a lightbox over non-menu content, (de)activate [`inert`](https://github.com/WICG/inert#tldr) on a menu, or focus an inner search `<input>`.

